### PR TITLE
Improve security in Nginx config

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -2,7 +2,7 @@ location PATHTOCHANGE {
         if ($scheme = http) {
                 rewrite ^ https://$server_name$request_uri? permanent;
         }
-        proxy_set_header Host $http_host;
+        proxy_set_header Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
After a check of nginx security level (with gixy, see more here : https://forum.yunohost.org/t/gixy-check-nginx-security/2892) I found that it's better to replace `$http_host` by `$host` in this case.