### PR TITLE
Update _common.sh

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -20,6 +20,7 @@ install_sources() {
         cd "$final_path"
         pip install --upgrade pip
         pip install --upgrade pyramid_chameleon
+        pip install soupsieve==1.9.5
         CFLAGS="-Wno-error -Wno-error=format-security" \
             ARCHFLAGS="-Wno-error=unused-command-line-argument-hard-error-in-future" \
             pip install --upgrade --requirement "$final_path/requirements.txt"


### PR DESCRIPTION
Since soupsieve has release version 2.0.0 python 3 is need.

So I try to force the soupsieve release to the last the support python2

A quick and perharps dirty hack