### PR TITLE
Remove very old CI upgrades that no longer work

### DIFF
--- a/check_process
+++ b/check_process
@@ -10,10 +10,6 @@
 		setup_private=0
 		setup_public=1
 		upgrade=1
-		# 1.6.2 from 05/03/2017
-		upgrade=1	from_commit=fd6350495d5a1d864ae30e1a61e18939fdb6a428
-		# 1.5 from 15/12/2016
-		upgrade=1	from_commit=267ccc21f7b52d22bc3d5b9cd6239857b9a82aad
 		backup_restore=1
 		multi_instance=1
 		port_already_use=0
@@ -21,10 +17,3 @@
 ;;; Options
 Email=jean-baptiste@holcroft.fr
 Notification=fail
-;;; Upgrade options
-	; commit=fd6350495d5a1d864ae30e1a61e18939fdb6a428
-		name=latest published version
-		manifest_arg=domain=DOMAIN&path=PATH
-	; commit=267ccc21f7b52d22bc3d5b9cd6239857b9a82aad
-		name=latest git commit before Jibec's rewriting
-		manifest_arg=domain=DOMAIN&path=PATH


### PR DESCRIPTION
## Problem

-  The CI was attempting to perform upgrades from very old YunoHost versions, and failing to do so because the old versions were too old for the CI to install

## Solution

- Remove those old versions

## PR Status

- [x] Code finished and ready to be reviewed/tested

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
