### PR TITLE
Fix log folder ownership when restoring

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -42,7 +42,7 @@ install_sources() {
 set_permissions() {
     chown $app -R $final_path
     chmod u=rwX,g=rX,o= -R $final_path
-    chown $app:root /var/log/uwsgi/$app
+    chown $app:root -R /var/log/uwsgi/$app
     chmod -R u=rwX,g=rX,o= /var/log/uwsgi/$app
 }
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -91,7 +91,7 @@ ynh_restore_uwsgi_service
 # RELOAD NGINX AND UWSGI
 #=================================================
 
-ynh_script_progression --message="Starting pgadmin services..." --weight=3
+ynh_script_progression --message="Starting $app services..." --weight=3
 ynh_systemd_action --service_name "uwsgi-app@$app.service" \
     --line_match "WSGI app 0 \(mountpoint='[/[:alnum:]_-]*'\) ready in [[:digit:]]* seconds on interpreter" --log_path "/var/log/uwsgi/$app/$app.log"
 ynh_systemd_action --service_name=nginx --action=reload


### PR DESCRIPTION
## Problem

- restore script fails with 

```
2022-02-08 11:48:18,255: DEBUG - Feb 08 00:42:40 uwsgi[51000]: open("/var/log/uwsgi/ffsync/ffsync.log"): Permission denied [core/logging.c line 288]
```
Full log [here](https://paste.yunohost.org/raw/xajovikexi).

## Solution

The owner of this log filewas not correctly restored. This PR fixes that (and fix a log while I was at it ;-) )

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
