### PR TITLE
FFsync has been deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> :warning: **Mozilla’s Firefox Sync Server is not maintained anymore upstream. Packaging is discontinued and installation is discouraged.**
+
 # Mozilla’s Sync Server for YunoHost
 
 [![Integration level](https://dash.yunohost.org/integration/ffsync.svg)](https://dash.yunohost.org/appci/app/ffsync) ![](https://ci-apps.yunohost.org/ci/badges/ffsync.status.svg) ![](https://ci-apps.yunohost.org/ci/badges/ffsync.maintain.svg)  

--- a/README_fr.md
+++ b/README_fr.md
@@ -1,3 +1,5 @@
+> :warning: **Firefox Sync Server n'est plus maintenue par Mozilla. Le packaging de l'app est arrêté et l'installation déconseillée.**
+
 # Serveur de synchronisation de Firefox pour YunoHost
 
 [![Integration level](https://dash.yunohost.org/integration/ffsync.svg)](https://dash.yunohost.org/appci/app/ffsync) ![](https://ci-apps.yunohost.org/ci/badges/ffsync.status.svg) ![](https://ci-apps.yunohost.org/ci/badges/ffsync.maintain.svg)  

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,13 @@
     "arguments": {
         "install" : [
             {
+                "name": "warning",
+                "type": "display_text",
+                "ask": {
+                    "en": "Firefox Sync Server is not maintained anymore by Mozilla. Installing is strongly discouraged.",
+                    "fr": "Firefox Sync Server n'est plus maintenue par Mozilla. L'installation est fortement déconseillée."
+                }
+            },            {
                 "name": "domain",
                 "type": "domain",
                 "ask": {


### PR DESCRIPTION
cf. upstream: https://github.com/mozilla-services/syncserver
The app still uses Python 2.7 and won't work with YunoHost anyways anymore.


## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
